### PR TITLE
Fix author for Qwen 2.5 citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ If you find our work helpful, feel free to give us a cite.
 @misc{qwen2.5,
     title = {Qwen2.5: A Party of Foundation Models},
     url = {https://qwenlm.github.io/blog/qwen2.5/},
-    author = {Qwen Team},
+    author = {{Qwen Team}},
     month = {September},
     year = {2024}
 }


### PR DESCRIPTION
As written, the bibtex citation will show up as `(Team, 2024)` in Latex. This fix makes it show up as `(Qwen Team, 2024)`, which I believe is what the authors intended.