### PR TITLE
getting_started/concepts Qwen2.5-Coder URL issue

### DIFF
--- a/docs/locales/zh_CN/LC_MESSAGES/getting_started/concepts.po
+++ b/docs/locales/zh_CN/LC_MESSAGES/getting_started/concepts.po
@@ -92,8 +92,8 @@ msgid "[CodeQwen1.5](https://github.com/QwenLM/CodeQwen1.5): 7B models"
 msgstr "[CodeQwen1.5](https://github.com/QwenLM/CodeQwen1.5): 7B 模型"
 
 #: ../../source/getting_started/concepts.md:25 eb627becc6cb4bbfb32cb1d1ce430bd6
-msgid "[Qwen2.5-Coder](https://github.com/QwenLM/Qwen2-Coder): 7B models"
-msgstr "[Qwen2.5-Coder](https://github.com/QwenLM/Qwen2-Coder): 7B 模型"
+msgid "[Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder): 7B models"
+msgstr "[Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder): 7B 模型"
 
 #: ../../source/getting_started/concepts.md:26 418115b8fefa411596c07ab9ce0cf9e7
 msgid "Qwen-Math: the language models for mathematics"

--- a/docs/source/getting_started/concepts.md
+++ b/docs/source/getting_started/concepts.md
@@ -22,7 +22,7 @@ The spectrum for the open-weight models spans over
     - [Qwen2-Audio](https://github.com/QwenLM/Qwen2-Audio): 7B-based models
 - CodeQwen/Qwen-Coder: the language models for coding
     - [CodeQwen1.5](https://github.com/QwenLM/CodeQwen1.5): 7B models
-    - [Qwen2.5-Coder](https://github.com/QwenLM/Qwen2-Coder): 7B models
+    - [Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder): 7B models
 - Qwen-Math: the language models for mathematics
     - [Qwen2-Math](https://github.com/QwenLM/Qwen2-Math): 1.5B, 7B, and 72B models
     - [Qwen2.5-Math](https://github.com/QwenLM/Qwen2.5-Math): 1.5B, 7B, and 72B models


### PR DESCRIPTION
Qwen2.5-Coder URL should be https://github.com/QwenLM/Qwen2.5-Coder

Change-Id: I802cbec7f694fbb6b1efe2a4ca2bc550376f7bd6