### PR TITLE
Fix prompt format in LlamaIndex.rst

### DIFF
--- a/docs/source/framework/LlamaIndex.rst
+++ b/docs/source/framework/LlamaIndex.rst
@@ -52,7 +52,7 @@ Qwen2.5 model families support a maximum of 32K context window size (up to 128K 
                 prompt += f"<|im_start|>assistant\n{message.content}<|im_end|>\n"
     
         if not prompt.startswith("<|im_start|>system"):
-            prompt = "<|im_start|>system\n" + prompt
+            prompt = "<|im_start|>system\n<|im_end|>\n" + prompt
     
         prompt = prompt + "<|im_start|>assistant\n"
     


### PR DESCRIPTION
When adding the placeholder system prompt if none was provided, the prompt is missing an <|im_end|> at the end of the system prompt.