### PR TITLE
Fix prompt format in LlamaIndex.rst 

### DIFF
--- a/docs/source/framework/LlamaIndex.rst
+++ b/docs/source/framework/LlamaIndex.rst
@@ -52,7 +52,7 @@ Qwen2.5 model families support a maximum of 32K context window size (up to 128K 
                 prompt += f"<|im_start|>assistant\n{message.content}<|im_end|>\n"
     
         if not prompt.startswith("<|im_start|>system"):
-            prompt = "<|im_start|>system\n" + prompt
+            prompt = "<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n" + prompt
     
         prompt = prompt + "<|im_start|>assistant\n"
     


### PR DESCRIPTION
This PR replaces #1234 which was accidentally merged and reverted. It incorporates the feedback provided.

If no system prompt is provided, this will add the default system prompt "You are Qwen, created by Alibaba Cloud. You are a helpful assistant." It will also add the missing <|im_end|> at the end of the system prompt.